### PR TITLE
Compatibility with TYPO3 Flow 2.3

### DIFF
--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,0 +1,10 @@
+Mw\Metamorph\Command\MorphCommandController:
+  properties:
+    console:
+      object:
+        name: Symfony\Component\Console\Output\ConsoleOutput
+
+Symfony\Component\Console\Output\ConsoleOutput:
+  className: Symfony\Component\Console\Output\ConsoleOutput
+  scope: prototype
+  autowiring: off


### PR DESCRIPTION
Adjust Metamorph to new APIs introduced in the stable release of
TYPO3 Flow 2.3. This mostly involves the usage of Symfony console
APIs.
