### PR TITLE
Require latest master version of gitlib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "typo3/flow": "*",
         "nikic/php-parser": "dev-master",
         "symfony/console": ">= 2.5",
-        "gitonomy/gitlib": "*",
+        "gitonomy/gitlib": "dev-master",
         "mittwald-typo3/flow-t3compat": "*",
         "helmich/flow-eventbroker": "*",
         "helmich/php-evaluator": "dev-master",


### PR DESCRIPTION
The latest stable release does not contain all required bugfixes.
