### PR TITLE
Correctly handle t3lib_div::makeInstance calls with expression arguments

### DIFF
--- a/Classes/Mw/Metamorph/Transformation/RewriteNodeVisitors/ReplaceMakeInstanceCallsVisitor.php
+++ b/Classes/Mw/Metamorph/Transformation/RewriteNodeVisitors/ReplaceMakeInstanceCallsVisitor.php
@@ -33,7 +33,7 @@ class ReplaceMakeInstanceCallsVisitor extends AbstractVisitor {
 				} else if ($className instanceof Node\Expr\Variable) {
 					// Do nothing, pass variable name as class name
 				} else {
-					$variableName = '_' . sha1(serialize($className));
+					$variableName       = '_' . sha1(serialize($className));
 					$variable           = new Node\Expr\Variable($variableName);
 					$variableAssignment = new Node\Expr\Assign(
 						$variable,
@@ -47,12 +47,18 @@ class ReplaceMakeInstanceCallsVisitor extends AbstractVisitor {
 				return new Node\Expr\New_($className, $args);
 			}
 		} else if ($node instanceof Node\Stmt && $this->addBeforeStmt !== NULL) {
-			$stmt = $this->addBeforeStmt;
+			$stmt                = $this->addBeforeStmt;
 			$this->addBeforeStmt = NULL;
-			return new Node\Stmt\If_(
-				new Node\Expr\ConstFetch(new Node\Name('TRUE')),
-				['stmts' => [$stmt, $node]]
-			);
+
+			if ($node instanceof Node\Stmt\ClassMethod) {
+				$node->stmts = array_merge([$stmt, $node->stmts]);
+				return $node;
+			} else {
+				return new Node\Stmt\If_(
+					new Node\Expr\ConstFetch(new Node\Name('TRUE')),
+					['stmts' => [$stmt, $node]]
+				);
+			}
 		}
 		return NULL;
 	}

--- a/Classes/Mw/Metamorph/Transformation/RewriteNodeVisitors/ReplaceMakeInstanceCallsVisitor.php
+++ b/Classes/Mw/Metamorph/Transformation/RewriteNodeVisitors/ReplaceMakeInstanceCallsVisitor.php
@@ -40,6 +40,10 @@ class ReplaceMakeInstanceCallsVisitor extends AbstractVisitor {
 						$className
 					);
 
+					// Usually, we could simply return an array of nodes here to insert the assignment
+					// statement directly before the `new` statement. However, if multiple visitors are
+					// assigned to the same NodeTraverser, these will have their `leaveNode` method
+					// called with an array of nodes, creating a fatal error.
 					$this->addBeforeStmt = $variableAssignment;
 					return new Node\Expr\New_($variable, $args);
 				}


### PR DESCRIPTION
`t3lib_div::makeInstance` can be called with other parameters that string literal. In these rare cases, simply using the string literal as class name won't work.