### PR TITLE
Incorrect value object handling

### DIFF
--- a/Classes/Mw/Metamorph/Domain/Model/Definition/FactContainer.php
+++ b/Classes/Mw/Metamorph/Domain/Model/Definition/FactContainer.php
@@ -67,6 +67,6 @@ class FactContainer {
 			return $this->factObjects[$factName];
 		}
 
-		return new NullFact();
+		throw new \InvalidArgumentException('Invalid fact name: "' . $factName . '"!');
 	}
 }

--- a/Classes/Mw/Metamorph/Step/TransformationVisitor/EntityDoctrineMigrationVisitor.php
+++ b/Classes/Mw/Metamorph/Step/TransformationVisitor/EntityDoctrineMigrationVisitor.php
@@ -72,7 +72,7 @@ class EntityDoctrineMigrationVisitor extends AbstractVisitor {
 				$annotation = new AnnotationRenderer('Flow', 'Entity');
 			}
 
-			if ($classDefinition->getFact('isDirectValueObjectDescendant')) {
+			if ($classDefinition->getFact('isDirectEntityOrValueObjectDescendant')) {
 				$node->extends = NULL;
 			}
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -133,8 +133,8 @@ Mw:
           class.getParentClass().getFullyQualifiedName() == 'Tx_Extbase_DomainObject_AbstractEntity'
       isDirectValueObjectDescendant:
         expr: |
-          class.getParentClass().getFullyQualifiedName() == 'TYPO3\\CMS\\Extbase\\DomainObject\\AbstractEntity' ||
-          class.getParentClass().getFullyQualifiedName() == 'Tx_Extbase_DomainObject_AbstractEntity'
+          class.getParentClass().getFullyQualifiedName() == 'TYPO3\\CMS\\Extbase\\DomainObject\\AbstractValueObject' ||
+          class.getParentClass().getFullyQualifiedName() == 'Tx_Extbase_DomainObject_AbstractValueObject'
       isDirectEntityOrValueObjectDescendant:
         expr: class.getFact('isDirectEntityDescendant') || class.getFact('isDirectValueObjectDescendant')
 


### PR DESCRIPTION
`TYPO3\CMS\Extbase\DomainObject\AbstractValueObject` inheritances are not removed.